### PR TITLE
Backspace to remove a tag

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -1,4 +1,4 @@
-(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({"/Users/tmcw/src/react-tag-list-input/demo.jsx":[function(require,module,exports){
+(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({"/Users/mgthesecond/projects/react-tag-list-input/demo.jsx":[function(require,module,exports){
 /** @jsx React.DOM */
 var React = require('react'),
   TagListForm = require('./index.jsx');
@@ -17,7 +17,7 @@ var Demo = React.createClass({displayName: 'Demo',
       React.DOM.div(null, 
         TagListForm({
           tags: tags, 
-          strict: true, 
+          strict: false, 
           onChange: this.onChange})
       )
     );
@@ -29,7 +29,7 @@ React.renderComponent(
   document.getElementById('app')
 );
 
-},{"./index.jsx":"/Users/tmcw/src/react-tag-list-input/index.jsx","react":"/Users/tmcw/src/react-tag-list-input/node_modules/react/react.js"}],"/Users/tmcw/src/react-tag-list-input/index.jsx":[function(require,module,exports){
+},{"./index.jsx":"/Users/mgthesecond/projects/react-tag-list-input/index.jsx","react":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/react.js"}],"/Users/mgthesecond/projects/react-tag-list-input/index.jsx":[function(require,module,exports){
 /** @jsx React.DOM */
 var React = require('react'),
   uniq = require('uniq'),
@@ -54,7 +54,7 @@ var TagListForm = React.createClass({displayName: 'TagListForm',
     e.preventDefault();
     if (!this.props.strict || this.tagIsValid(this.state.tag)) {
       this.setState({
-        tags: uniq(this.state.tags.concat([this.state.tag])),
+        tags: uniq(this.state.tags.concat([this.state.tag]), undefined, true),
         tag: ''
       }, this.fireChange);
     }
@@ -75,6 +75,16 @@ var TagListForm = React.createClass({displayName: 'TagListForm',
   },
   focusForm: function(e) {
     this.refs.tagInput.getDOMNode().focus();
+  },
+  handleBackspace: function(e){
+    if(e.keyCode == 8 && this.state.tags.length > 0 && this.state.tag.length==0){
+      this.setState({
+        tags: this.state.tags.filter(function(t,i){
+          return i !== (this.state.tags.length-1)
+        }, this)
+      }, this.fireChange);  
+      e.preventDefault();
+    }
   },
   render: function() {
     var currentTags = this.state.tags.reduce(function(memo, tag) {
@@ -108,6 +118,7 @@ var TagListForm = React.createClass({displayName: 'TagListForm',
             list: listId, 
             value: this.state.tag, 
             onChange: this.inputChange, 
+            onKeyUp: this.handleBackspace, 
             className: "tag-list-form-input", 
             type: "text"}), 
           React.DOM.datalist({id: listId}, 
@@ -123,7 +134,7 @@ var TagListForm = React.createClass({displayName: 'TagListForm',
 
 module.exports = TagListForm;
 
-},{"okay-hash":"/Users/tmcw/src/react-tag-list-input/node_modules/okay-hash/index.js","react":"/Users/tmcw/src/react-tag-list-input/node_modules/react/react.js","uniq":"/Users/tmcw/src/react-tag-list-input/node_modules/uniq/uniq.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/okay-hash/index.js":[function(require,module,exports){
+},{"okay-hash":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/okay-hash/index.js","react":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/react.js","uniq":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/uniq/uniq.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/okay-hash/index.js":[function(require,module,exports){
 function okhash(x) {
     if (!x || !x.length) return 0;
     for (var i = 0, h = 0; i < x.length; i++) {
@@ -134,7 +145,7 @@ function okhash(x) {
 
 if (typeof module !== 'undefined') module.exports = okhash;
 
-},{}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/AutoFocusMixin.js":[function(require,module,exports){
+},{}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/AutoFocusMixin.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -168,7 +179,7 @@ var AutoFocusMixin = {
 
 module.exports = AutoFocusMixin;
 
-},{"./focusNode":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/focusNode.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/BeforeInputEventPlugin.js":[function(require,module,exports){
+},{"./focusNode":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/focusNode.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/BeforeInputEventPlugin.js":[function(require,module,exports){
 /**
  * Copyright 2013 Facebook, Inc.
  *
@@ -392,7 +403,7 @@ var BeforeInputEventPlugin = {
 
 module.exports = BeforeInputEventPlugin;
 
-},{"./EventConstants":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/EventConstants.js","./EventPropagators":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/EventPropagators.js","./ExecutionEnvironment":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ExecutionEnvironment.js","./SyntheticInputEvent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SyntheticInputEvent.js","./keyOf":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/keyOf.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/CSSProperty.js":[function(require,module,exports){
+},{"./EventConstants":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/EventConstants.js","./EventPropagators":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/EventPropagators.js","./ExecutionEnvironment":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ExecutionEnvironment.js","./SyntheticInputEvent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SyntheticInputEvent.js","./keyOf":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/keyOf.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/CSSProperty.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -515,7 +526,7 @@ var CSSProperty = {
 
 module.exports = CSSProperty;
 
-},{}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/CSSPropertyOperations.js":[function(require,module,exports){
+},{}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/CSSPropertyOperations.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -614,7 +625,7 @@ var CSSPropertyOperations = {
 
 module.exports = CSSPropertyOperations;
 
-},{"./CSSProperty":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/CSSProperty.js","./dangerousStyleValue":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/dangerousStyleValue.js","./hyphenateStyleName":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/hyphenateStyleName.js","./memoizeStringOnly":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/memoizeStringOnly.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/CallbackQueue.js":[function(require,module,exports){
+},{"./CSSProperty":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/CSSProperty.js","./dangerousStyleValue":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/dangerousStyleValue.js","./hyphenateStyleName":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/hyphenateStyleName.js","./memoizeStringOnly":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/memoizeStringOnly.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/CallbackQueue.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -721,7 +732,7 @@ PooledClass.addPoolingTo(CallbackQueue);
 module.exports = CallbackQueue;
 
 }).call(this,require('_process'))
-},{"./PooledClass":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/PooledClass.js","./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","./mixInto":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/mixInto.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ChangeEventPlugin.js":[function(require,module,exports){
+},{"./PooledClass":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/PooledClass.js","./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","./mixInto":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/mixInto.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ChangeEventPlugin.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -1110,7 +1121,7 @@ var ChangeEventPlugin = {
 
 module.exports = ChangeEventPlugin;
 
-},{"./EventConstants":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/EventConstants.js","./EventPluginHub":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/EventPluginHub.js","./EventPropagators":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/EventPropagators.js","./ExecutionEnvironment":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ExecutionEnvironment.js","./ReactUpdates":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactUpdates.js","./SyntheticEvent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SyntheticEvent.js","./isEventSupported":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/isEventSupported.js","./isTextInputElement":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/isTextInputElement.js","./keyOf":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/keyOf.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ClientReactRootIndex.js":[function(require,module,exports){
+},{"./EventConstants":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/EventConstants.js","./EventPluginHub":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/EventPluginHub.js","./EventPropagators":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/EventPropagators.js","./ExecutionEnvironment":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ExecutionEnvironment.js","./ReactUpdates":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactUpdates.js","./SyntheticEvent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SyntheticEvent.js","./isEventSupported":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/isEventSupported.js","./isTextInputElement":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/isTextInputElement.js","./keyOf":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/keyOf.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ClientReactRootIndex.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -1142,7 +1153,7 @@ var ClientReactRootIndex = {
 
 module.exports = ClientReactRootIndex;
 
-},{}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/CompositionEventPlugin.js":[function(require,module,exports){
+},{}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/CompositionEventPlugin.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -1408,7 +1419,7 @@ var CompositionEventPlugin = {
 
 module.exports = CompositionEventPlugin;
 
-},{"./EventConstants":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/EventConstants.js","./EventPropagators":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/EventPropagators.js","./ExecutionEnvironment":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ExecutionEnvironment.js","./ReactInputSelection":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactInputSelection.js","./SyntheticCompositionEvent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SyntheticCompositionEvent.js","./getTextContentAccessor":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/getTextContentAccessor.js","./keyOf":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/keyOf.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/DOMChildrenOperations.js":[function(require,module,exports){
+},{"./EventConstants":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/EventConstants.js","./EventPropagators":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/EventPropagators.js","./ExecutionEnvironment":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ExecutionEnvironment.js","./ReactInputSelection":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactInputSelection.js","./SyntheticCompositionEvent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SyntheticCompositionEvent.js","./getTextContentAccessor":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/getTextContentAccessor.js","./keyOf":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/keyOf.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/DOMChildrenOperations.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -1590,7 +1601,7 @@ var DOMChildrenOperations = {
 module.exports = DOMChildrenOperations;
 
 }).call(this,require('_process'))
-},{"./Danger":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/Danger.js","./ReactMultiChildUpdateTypes":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactMultiChildUpdateTypes.js","./getTextContentAccessor":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/getTextContentAccessor.js","./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/DOMProperty.js":[function(require,module,exports){
+},{"./Danger":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/Danger.js","./ReactMultiChildUpdateTypes":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactMultiChildUpdateTypes.js","./getTextContentAccessor":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/getTextContentAccessor.js","./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/DOMProperty.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -1892,7 +1903,7 @@ var DOMProperty = {
 module.exports = DOMProperty;
 
 }).call(this,require('_process'))
-},{"./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/DOMPropertyOperations.js":[function(require,module,exports){
+},{"./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/DOMPropertyOperations.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -2089,7 +2100,7 @@ var DOMPropertyOperations = {
 module.exports = DOMPropertyOperations;
 
 }).call(this,require('_process'))
-},{"./DOMProperty":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/DOMProperty.js","./escapeTextForBrowser":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/escapeTextForBrowser.js","./memoizeStringOnly":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/memoizeStringOnly.js","./warning":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/warning.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/Danger.js":[function(require,module,exports){
+},{"./DOMProperty":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/DOMProperty.js","./escapeTextForBrowser":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/escapeTextForBrowser.js","./memoizeStringOnly":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/memoizeStringOnly.js","./warning":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/warning.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/Danger.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -2280,7 +2291,7 @@ var Danger = {
 module.exports = Danger;
 
 }).call(this,require('_process'))
-},{"./ExecutionEnvironment":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ExecutionEnvironment.js","./createNodesFromMarkup":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/createNodesFromMarkup.js","./emptyFunction":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/emptyFunction.js","./getMarkupWrap":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/getMarkupWrap.js","./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/DefaultEventPluginOrder.js":[function(require,module,exports){
+},{"./ExecutionEnvironment":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ExecutionEnvironment.js","./createNodesFromMarkup":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/createNodesFromMarkup.js","./emptyFunction":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/emptyFunction.js","./getMarkupWrap":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/getMarkupWrap.js","./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/DefaultEventPluginOrder.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -2327,7 +2338,7 @@ var DefaultEventPluginOrder = [
 
 module.exports = DefaultEventPluginOrder;
 
-},{"./keyOf":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/keyOf.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/EnterLeaveEventPlugin.js":[function(require,module,exports){
+},{"./keyOf":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/keyOf.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/EnterLeaveEventPlugin.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -2474,7 +2485,7 @@ var EnterLeaveEventPlugin = {
 
 module.exports = EnterLeaveEventPlugin;
 
-},{"./EventConstants":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/EventConstants.js","./EventPropagators":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/EventPropagators.js","./ReactMount":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactMount.js","./SyntheticMouseEvent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SyntheticMouseEvent.js","./keyOf":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/keyOf.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/EventConstants.js":[function(require,module,exports){
+},{"./EventConstants":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/EventConstants.js","./EventPropagators":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/EventPropagators.js","./ReactMount":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactMount.js","./SyntheticMouseEvent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SyntheticMouseEvent.js","./keyOf":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/keyOf.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/EventConstants.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -2553,7 +2564,7 @@ var EventConstants = {
 
 module.exports = EventConstants;
 
-},{"./keyMirror":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/keyMirror.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/EventListener.js":[function(require,module,exports){
+},{"./keyMirror":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/keyMirror.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/EventListener.js":[function(require,module,exports){
 (function (process){
 /**
  * @providesModule EventListener
@@ -2629,7 +2640,7 @@ var EventListener = {
 module.exports = EventListener;
 
 }).call(this,require('_process'))
-},{"./emptyFunction":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/emptyFunction.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/EventPluginHub.js":[function(require,module,exports){
+},{"./emptyFunction":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/emptyFunction.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/EventPluginHub.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -2923,7 +2934,7 @@ var EventPluginHub = {
 module.exports = EventPluginHub;
 
 }).call(this,require('_process'))
-},{"./EventPluginRegistry":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/EventPluginRegistry.js","./EventPluginUtils":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/EventPluginUtils.js","./accumulate":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/accumulate.js","./forEachAccumulated":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/forEachAccumulated.js","./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","./isEventSupported":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/isEventSupported.js","./monitorCodeUse":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/monitorCodeUse.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/EventPluginRegistry.js":[function(require,module,exports){
+},{"./EventPluginRegistry":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/EventPluginRegistry.js","./EventPluginUtils":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/EventPluginUtils.js","./accumulate":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/accumulate.js","./forEachAccumulated":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/forEachAccumulated.js","./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","./isEventSupported":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/isEventSupported.js","./monitorCodeUse":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/monitorCodeUse.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/EventPluginRegistry.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -3210,7 +3221,7 @@ var EventPluginRegistry = {
 module.exports = EventPluginRegistry;
 
 }).call(this,require('_process'))
-},{"./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/EventPluginUtils.js":[function(require,module,exports){
+},{"./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/EventPluginUtils.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -3438,7 +3449,7 @@ var EventPluginUtils = {
 module.exports = EventPluginUtils;
 
 }).call(this,require('_process'))
-},{"./EventConstants":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/EventConstants.js","./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/EventPropagators.js":[function(require,module,exports){
+},{"./EventConstants":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/EventConstants.js","./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/EventPropagators.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -3585,7 +3596,7 @@ var EventPropagators = {
 module.exports = EventPropagators;
 
 }).call(this,require('_process'))
-},{"./EventConstants":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/EventConstants.js","./EventPluginHub":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/EventPluginHub.js","./accumulate":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/accumulate.js","./forEachAccumulated":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/forEachAccumulated.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ExecutionEnvironment.js":[function(require,module,exports){
+},{"./EventConstants":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/EventConstants.js","./EventPluginHub":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/EventPluginHub.js","./accumulate":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/accumulate.js","./forEachAccumulated":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/forEachAccumulated.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ExecutionEnvironment.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -3637,7 +3648,7 @@ var ExecutionEnvironment = {
 
 module.exports = ExecutionEnvironment;
 
-},{}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/HTMLDOMPropertyConfig.js":[function(require,module,exports){
+},{}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/HTMLDOMPropertyConfig.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -3828,7 +3839,7 @@ var HTMLDOMPropertyConfig = {
 
 module.exports = HTMLDOMPropertyConfig;
 
-},{"./DOMProperty":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/DOMProperty.js","./ExecutionEnvironment":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ExecutionEnvironment.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/LinkedValueUtils.js":[function(require,module,exports){
+},{"./DOMProperty":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/DOMProperty.js","./ExecutionEnvironment":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ExecutionEnvironment.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/LinkedValueUtils.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -3991,7 +4002,7 @@ var LinkedValueUtils = {
 module.exports = LinkedValueUtils;
 
 }).call(this,require('_process'))
-},{"./ReactPropTypes":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactPropTypes.js","./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/LocalEventTrapMixin.js":[function(require,module,exports){
+},{"./ReactPropTypes":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactPropTypes.js","./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/LocalEventTrapMixin.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2014 Facebook, Inc.
@@ -4047,7 +4058,7 @@ var LocalEventTrapMixin = {
 module.exports = LocalEventTrapMixin;
 
 }).call(this,require('_process'))
-},{"./ReactBrowserEventEmitter":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactBrowserEventEmitter.js","./accumulate":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/accumulate.js","./forEachAccumulated":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/forEachAccumulated.js","./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/MobileSafariClickEventPlugin.js":[function(require,module,exports){
+},{"./ReactBrowserEventEmitter":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactBrowserEventEmitter.js","./accumulate":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/accumulate.js","./forEachAccumulated":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/forEachAccumulated.js","./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/MobileSafariClickEventPlugin.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -4112,7 +4123,7 @@ var MobileSafariClickEventPlugin = {
 
 module.exports = MobileSafariClickEventPlugin;
 
-},{"./EventConstants":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/EventConstants.js","./emptyFunction":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/emptyFunction.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/PooledClass.js":[function(require,module,exports){
+},{"./EventConstants":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/EventConstants.js","./emptyFunction":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/emptyFunction.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/PooledClass.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -4235,7 +4246,7 @@ var PooledClass = {
 module.exports = PooledClass;
 
 }).call(this,require('_process'))
-},{"./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/React.js":[function(require,module,exports){
+},{"./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/React.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -4390,7 +4401,7 @@ React.version = '0.11.2';
 module.exports = React;
 
 }).call(this,require('_process'))
-},{"./DOMPropertyOperations":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/DOMPropertyOperations.js","./EventPluginUtils":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/EventPluginUtils.js","./ExecutionEnvironment":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ExecutionEnvironment.js","./ReactChildren":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactChildren.js","./ReactComponent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactComponent.js","./ReactCompositeComponent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactCompositeComponent.js","./ReactContext":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactContext.js","./ReactCurrentOwner":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactCurrentOwner.js","./ReactDOM":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDOM.js","./ReactDOMComponent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDOMComponent.js","./ReactDefaultInjection":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDefaultInjection.js","./ReactDescriptor":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDescriptor.js","./ReactInstanceHandles":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactInstanceHandles.js","./ReactMount":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactMount.js","./ReactMultiChild":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactMultiChild.js","./ReactPerf":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactPerf.js","./ReactPropTypes":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactPropTypes.js","./ReactServerRendering":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactServerRendering.js","./ReactTextComponent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactTextComponent.js","./onlyChild":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/onlyChild.js","./warning":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/warning.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactBrowserComponentMixin.js":[function(require,module,exports){
+},{"./DOMPropertyOperations":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/DOMPropertyOperations.js","./EventPluginUtils":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/EventPluginUtils.js","./ExecutionEnvironment":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ExecutionEnvironment.js","./ReactChildren":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactChildren.js","./ReactComponent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactComponent.js","./ReactCompositeComponent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactCompositeComponent.js","./ReactContext":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactContext.js","./ReactCurrentOwner":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactCurrentOwner.js","./ReactDOM":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDOM.js","./ReactDOMComponent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDOMComponent.js","./ReactDefaultInjection":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDefaultInjection.js","./ReactDescriptor":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDescriptor.js","./ReactInstanceHandles":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactInstanceHandles.js","./ReactMount":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactMount.js","./ReactMultiChild":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactMultiChild.js","./ReactPerf":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactPerf.js","./ReactPropTypes":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactPropTypes.js","./ReactServerRendering":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactServerRendering.js","./ReactTextComponent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactTextComponent.js","./onlyChild":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/onlyChild.js","./warning":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/warning.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactBrowserComponentMixin.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -4440,7 +4451,7 @@ var ReactBrowserComponentMixin = {
 module.exports = ReactBrowserComponentMixin;
 
 }).call(this,require('_process'))
-},{"./ReactEmptyComponent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactEmptyComponent.js","./ReactMount":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactMount.js","./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactBrowserEventEmitter.js":[function(require,module,exports){
+},{"./ReactEmptyComponent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactEmptyComponent.js","./ReactMount":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactMount.js","./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactBrowserEventEmitter.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -4802,7 +4813,7 @@ var ReactBrowserEventEmitter = merge(ReactEventEmitterMixin, {
 
 module.exports = ReactBrowserEventEmitter;
 
-},{"./EventConstants":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/EventConstants.js","./EventPluginHub":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/EventPluginHub.js","./EventPluginRegistry":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/EventPluginRegistry.js","./ReactEventEmitterMixin":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactEventEmitterMixin.js","./ViewportMetrics":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ViewportMetrics.js","./isEventSupported":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/isEventSupported.js","./merge":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/merge.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactChildren.js":[function(require,module,exports){
+},{"./EventConstants":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/EventConstants.js","./EventPluginHub":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/EventPluginHub.js","./EventPluginRegistry":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/EventPluginRegistry.js","./ReactEventEmitterMixin":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactEventEmitterMixin.js","./ViewportMetrics":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ViewportMetrics.js","./isEventSupported":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/isEventSupported.js","./merge":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/merge.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactChildren.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -4959,7 +4970,7 @@ var ReactChildren = {
 module.exports = ReactChildren;
 
 }).call(this,require('_process'))
-},{"./PooledClass":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/PooledClass.js","./traverseAllChildren":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/traverseAllChildren.js","./warning":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/warning.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactComponent.js":[function(require,module,exports){
+},{"./PooledClass":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/PooledClass.js","./traverseAllChildren":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/traverseAllChildren.js","./warning":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/warning.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactComponent.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -5409,7 +5420,7 @@ var ReactComponent = {
 module.exports = ReactComponent;
 
 }).call(this,require('_process'))
-},{"./ReactDescriptor":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDescriptor.js","./ReactOwner":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactOwner.js","./ReactUpdates":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactUpdates.js","./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","./keyMirror":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/keyMirror.js","./merge":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/merge.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactComponentBrowserEnvironment.js":[function(require,module,exports){
+},{"./ReactDescriptor":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDescriptor.js","./ReactOwner":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactOwner.js","./ReactUpdates":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactUpdates.js","./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","./keyMirror":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/keyMirror.js","./merge":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/merge.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactComponentBrowserEnvironment.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -5538,7 +5549,7 @@ var ReactComponentBrowserEnvironment = {
 module.exports = ReactComponentBrowserEnvironment;
 
 }).call(this,require('_process'))
-},{"./ReactDOMIDOperations":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDOMIDOperations.js","./ReactMarkupChecksum":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactMarkupChecksum.js","./ReactMount":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactMount.js","./ReactPerf":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactPerf.js","./ReactReconcileTransaction":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactReconcileTransaction.js","./getReactRootElementInContainer":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/getReactRootElementInContainer.js","./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","./setInnerHTML":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/setInnerHTML.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactCompositeComponent.js":[function(require,module,exports){
+},{"./ReactDOMIDOperations":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDOMIDOperations.js","./ReactMarkupChecksum":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactMarkupChecksum.js","./ReactMount":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactMount.js","./ReactPerf":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactPerf.js","./ReactReconcileTransaction":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactReconcileTransaction.js","./getReactRootElementInContainer":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/getReactRootElementInContainer.js","./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","./setInnerHTML":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/setInnerHTML.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactCompositeComponent.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -6967,7 +6978,7 @@ var ReactCompositeComponent = {
 module.exports = ReactCompositeComponent;
 
 }).call(this,require('_process'))
-},{"./ReactComponent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactComponent.js","./ReactContext":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactContext.js","./ReactCurrentOwner":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactCurrentOwner.js","./ReactDescriptor":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDescriptor.js","./ReactDescriptorValidator":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDescriptorValidator.js","./ReactEmptyComponent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactEmptyComponent.js","./ReactErrorUtils":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactErrorUtils.js","./ReactOwner":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactOwner.js","./ReactPerf":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactPerf.js","./ReactPropTransferer":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactPropTransferer.js","./ReactPropTypeLocationNames":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactPropTypeLocationNames.js","./ReactPropTypeLocations":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactPropTypeLocations.js","./ReactUpdates":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactUpdates.js","./instantiateReactComponent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/instantiateReactComponent.js","./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","./keyMirror":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/keyMirror.js","./mapObject":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/mapObject.js","./merge":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/merge.js","./mixInto":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/mixInto.js","./monitorCodeUse":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/monitorCodeUse.js","./shouldUpdateReactComponent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/shouldUpdateReactComponent.js","./warning":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/warning.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactContext.js":[function(require,module,exports){
+},{"./ReactComponent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactComponent.js","./ReactContext":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactContext.js","./ReactCurrentOwner":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactCurrentOwner.js","./ReactDescriptor":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDescriptor.js","./ReactDescriptorValidator":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDescriptorValidator.js","./ReactEmptyComponent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactEmptyComponent.js","./ReactErrorUtils":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactErrorUtils.js","./ReactOwner":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactOwner.js","./ReactPerf":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactPerf.js","./ReactPropTransferer":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactPropTransferer.js","./ReactPropTypeLocationNames":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactPropTypeLocationNames.js","./ReactPropTypeLocations":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactPropTypeLocations.js","./ReactUpdates":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactUpdates.js","./instantiateReactComponent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/instantiateReactComponent.js","./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","./keyMirror":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/keyMirror.js","./mapObject":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/mapObject.js","./merge":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/merge.js","./mixInto":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/mixInto.js","./monitorCodeUse":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/monitorCodeUse.js","./shouldUpdateReactComponent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/shouldUpdateReactComponent.js","./warning":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/warning.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactContext.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -7036,7 +7047,7 @@ var ReactContext = {
 
 module.exports = ReactContext;
 
-},{"./merge":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/merge.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactCurrentOwner.js":[function(require,module,exports){
+},{"./merge":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/merge.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactCurrentOwner.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -7077,7 +7088,7 @@ var ReactCurrentOwner = {
 
 module.exports = ReactCurrentOwner;
 
-},{}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDOM.js":[function(require,module,exports){
+},{}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDOM.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -7292,7 +7303,7 @@ ReactDOM.injection = injection;
 module.exports = ReactDOM;
 
 }).call(this,require('_process'))
-},{"./ReactDOMComponent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDOMComponent.js","./ReactDescriptor":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDescriptor.js","./ReactDescriptorValidator":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDescriptorValidator.js","./mapObject":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/mapObject.js","./mergeInto":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/mergeInto.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDOMButton.js":[function(require,module,exports){
+},{"./ReactDOMComponent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDOMComponent.js","./ReactDescriptor":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDescriptor.js","./ReactDescriptorValidator":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDescriptorValidator.js","./mapObject":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/mapObject.js","./mergeInto":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/mergeInto.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDOMButton.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -7363,7 +7374,7 @@ var ReactDOMButton = ReactCompositeComponent.createClass({
 
 module.exports = ReactDOMButton;
 
-},{"./AutoFocusMixin":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/AutoFocusMixin.js","./ReactBrowserComponentMixin":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactBrowserComponentMixin.js","./ReactCompositeComponent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactCompositeComponent.js","./ReactDOM":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDOM.js","./keyMirror":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/keyMirror.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDOMComponent.js":[function(require,module,exports){
+},{"./AutoFocusMixin":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/AutoFocusMixin.js","./ReactBrowserComponentMixin":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactBrowserComponentMixin.js","./ReactCompositeComponent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactCompositeComponent.js","./ReactDOM":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDOM.js","./keyMirror":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/keyMirror.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDOMComponent.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -7785,7 +7796,7 @@ mixInto(ReactDOMComponent, ReactBrowserComponentMixin);
 module.exports = ReactDOMComponent;
 
 }).call(this,require('_process'))
-},{"./CSSPropertyOperations":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/CSSPropertyOperations.js","./DOMProperty":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/DOMProperty.js","./DOMPropertyOperations":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/DOMPropertyOperations.js","./ReactBrowserComponentMixin":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactBrowserComponentMixin.js","./ReactBrowserEventEmitter":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactBrowserEventEmitter.js","./ReactComponent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactComponent.js","./ReactMount":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactMount.js","./ReactMultiChild":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactMultiChild.js","./ReactPerf":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactPerf.js","./escapeTextForBrowser":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/escapeTextForBrowser.js","./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","./keyOf":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/keyOf.js","./merge":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/merge.js","./mixInto":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/mixInto.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDOMForm.js":[function(require,module,exports){
+},{"./CSSPropertyOperations":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/CSSPropertyOperations.js","./DOMProperty":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/DOMProperty.js","./DOMPropertyOperations":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/DOMPropertyOperations.js","./ReactBrowserComponentMixin":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactBrowserComponentMixin.js","./ReactBrowserEventEmitter":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactBrowserEventEmitter.js","./ReactComponent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactComponent.js","./ReactMount":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactMount.js","./ReactMultiChild":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactMultiChild.js","./ReactPerf":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactPerf.js","./escapeTextForBrowser":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/escapeTextForBrowser.js","./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","./keyOf":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/keyOf.js","./merge":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/merge.js","./mixInto":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/mixInto.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDOMForm.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -7841,7 +7852,7 @@ var ReactDOMForm = ReactCompositeComponent.createClass({
 
 module.exports = ReactDOMForm;
 
-},{"./EventConstants":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/EventConstants.js","./LocalEventTrapMixin":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/LocalEventTrapMixin.js","./ReactBrowserComponentMixin":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactBrowserComponentMixin.js","./ReactCompositeComponent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactCompositeComponent.js","./ReactDOM":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDOM.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDOMIDOperations.js":[function(require,module,exports){
+},{"./EventConstants":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/EventConstants.js","./LocalEventTrapMixin":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/LocalEventTrapMixin.js","./ReactBrowserComponentMixin":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactBrowserComponentMixin.js","./ReactCompositeComponent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactCompositeComponent.js","./ReactDOM":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDOM.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDOMIDOperations.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -8034,7 +8045,7 @@ var ReactDOMIDOperations = {
 module.exports = ReactDOMIDOperations;
 
 }).call(this,require('_process'))
-},{"./CSSPropertyOperations":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/CSSPropertyOperations.js","./DOMChildrenOperations":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/DOMChildrenOperations.js","./DOMPropertyOperations":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/DOMPropertyOperations.js","./ReactMount":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactMount.js","./ReactPerf":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactPerf.js","./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","./setInnerHTML":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/setInnerHTML.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDOMImg.js":[function(require,module,exports){
+},{"./CSSPropertyOperations":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/CSSPropertyOperations.js","./DOMChildrenOperations":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/DOMChildrenOperations.js","./DOMPropertyOperations":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/DOMPropertyOperations.js","./ReactMount":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactMount.js","./ReactPerf":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactPerf.js","./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","./setInnerHTML":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/setInnerHTML.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDOMImg.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -8088,7 +8099,7 @@ var ReactDOMImg = ReactCompositeComponent.createClass({
 
 module.exports = ReactDOMImg;
 
-},{"./EventConstants":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/EventConstants.js","./LocalEventTrapMixin":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/LocalEventTrapMixin.js","./ReactBrowserComponentMixin":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactBrowserComponentMixin.js","./ReactCompositeComponent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactCompositeComponent.js","./ReactDOM":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDOM.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDOMInput.js":[function(require,module,exports){
+},{"./EventConstants":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/EventConstants.js","./LocalEventTrapMixin":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/LocalEventTrapMixin.js","./ReactBrowserComponentMixin":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactBrowserComponentMixin.js","./ReactCompositeComponent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactCompositeComponent.js","./ReactDOM":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDOM.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDOMInput.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -8274,7 +8285,7 @@ var ReactDOMInput = ReactCompositeComponent.createClass({
 module.exports = ReactDOMInput;
 
 }).call(this,require('_process'))
-},{"./AutoFocusMixin":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/AutoFocusMixin.js","./DOMPropertyOperations":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/DOMPropertyOperations.js","./LinkedValueUtils":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/LinkedValueUtils.js","./ReactBrowserComponentMixin":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactBrowserComponentMixin.js","./ReactCompositeComponent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactCompositeComponent.js","./ReactDOM":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDOM.js","./ReactMount":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactMount.js","./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","./merge":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/merge.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDOMOption.js":[function(require,module,exports){
+},{"./AutoFocusMixin":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/AutoFocusMixin.js","./DOMPropertyOperations":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/DOMPropertyOperations.js","./LinkedValueUtils":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/LinkedValueUtils.js","./ReactBrowserComponentMixin":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactBrowserComponentMixin.js","./ReactCompositeComponent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactCompositeComponent.js","./ReactDOM":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDOM.js","./ReactMount":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactMount.js","./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","./merge":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/merge.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDOMOption.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -8333,7 +8344,7 @@ var ReactDOMOption = ReactCompositeComponent.createClass({
 module.exports = ReactDOMOption;
 
 }).call(this,require('_process'))
-},{"./ReactBrowserComponentMixin":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactBrowserComponentMixin.js","./ReactCompositeComponent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactCompositeComponent.js","./ReactDOM":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDOM.js","./warning":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/warning.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDOMSelect.js":[function(require,module,exports){
+},{"./ReactBrowserComponentMixin":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactBrowserComponentMixin.js","./ReactCompositeComponent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactCompositeComponent.js","./ReactDOM":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDOM.js","./warning":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/warning.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDOMSelect.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -8516,7 +8527,7 @@ var ReactDOMSelect = ReactCompositeComponent.createClass({
 
 module.exports = ReactDOMSelect;
 
-},{"./AutoFocusMixin":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/AutoFocusMixin.js","./LinkedValueUtils":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/LinkedValueUtils.js","./ReactBrowserComponentMixin":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactBrowserComponentMixin.js","./ReactCompositeComponent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactCompositeComponent.js","./ReactDOM":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDOM.js","./merge":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/merge.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDOMSelection.js":[function(require,module,exports){
+},{"./AutoFocusMixin":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/AutoFocusMixin.js","./LinkedValueUtils":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/LinkedValueUtils.js","./ReactBrowserComponentMixin":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactBrowserComponentMixin.js","./ReactCompositeComponent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactCompositeComponent.js","./ReactDOM":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDOM.js","./merge":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/merge.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDOMSelection.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -8732,7 +8743,7 @@ var ReactDOMSelection = {
 
 module.exports = ReactDOMSelection;
 
-},{"./ExecutionEnvironment":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ExecutionEnvironment.js","./getNodeForCharacterOffset":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/getNodeForCharacterOffset.js","./getTextContentAccessor":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/getTextContentAccessor.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDOMTextarea.js":[function(require,module,exports){
+},{"./ExecutionEnvironment":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ExecutionEnvironment.js","./getNodeForCharacterOffset":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/getNodeForCharacterOffset.js","./getTextContentAccessor":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/getTextContentAccessor.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDOMTextarea.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -8878,7 +8889,7 @@ var ReactDOMTextarea = ReactCompositeComponent.createClass({
 module.exports = ReactDOMTextarea;
 
 }).call(this,require('_process'))
-},{"./AutoFocusMixin":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/AutoFocusMixin.js","./DOMPropertyOperations":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/DOMPropertyOperations.js","./LinkedValueUtils":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/LinkedValueUtils.js","./ReactBrowserComponentMixin":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactBrowserComponentMixin.js","./ReactCompositeComponent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactCompositeComponent.js","./ReactDOM":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDOM.js","./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","./merge":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/merge.js","./warning":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/warning.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDefaultBatchingStrategy.js":[function(require,module,exports){
+},{"./AutoFocusMixin":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/AutoFocusMixin.js","./DOMPropertyOperations":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/DOMPropertyOperations.js","./LinkedValueUtils":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/LinkedValueUtils.js","./ReactBrowserComponentMixin":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactBrowserComponentMixin.js","./ReactCompositeComponent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactCompositeComponent.js","./ReactDOM":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDOM.js","./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","./merge":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/merge.js","./warning":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/warning.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDefaultBatchingStrategy.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -8955,7 +8966,7 @@ var ReactDefaultBatchingStrategy = {
 
 module.exports = ReactDefaultBatchingStrategy;
 
-},{"./ReactUpdates":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactUpdates.js","./Transaction":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/Transaction.js","./emptyFunction":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/emptyFunction.js","./mixInto":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/mixInto.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDefaultInjection.js":[function(require,module,exports){
+},{"./ReactUpdates":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactUpdates.js","./Transaction":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/Transaction.js","./emptyFunction":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/emptyFunction.js","./mixInto":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/mixInto.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDefaultInjection.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -9087,7 +9098,7 @@ module.exports = {
 };
 
 }).call(this,require('_process'))
-},{"./BeforeInputEventPlugin":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/BeforeInputEventPlugin.js","./ChangeEventPlugin":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ChangeEventPlugin.js","./ClientReactRootIndex":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ClientReactRootIndex.js","./CompositionEventPlugin":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/CompositionEventPlugin.js","./DefaultEventPluginOrder":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/DefaultEventPluginOrder.js","./EnterLeaveEventPlugin":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/EnterLeaveEventPlugin.js","./ExecutionEnvironment":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ExecutionEnvironment.js","./HTMLDOMPropertyConfig":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/HTMLDOMPropertyConfig.js","./MobileSafariClickEventPlugin":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/MobileSafariClickEventPlugin.js","./ReactBrowserComponentMixin":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactBrowserComponentMixin.js","./ReactComponentBrowserEnvironment":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactComponentBrowserEnvironment.js","./ReactDOM":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDOM.js","./ReactDOMButton":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDOMButton.js","./ReactDOMForm":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDOMForm.js","./ReactDOMImg":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDOMImg.js","./ReactDOMInput":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDOMInput.js","./ReactDOMOption":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDOMOption.js","./ReactDOMSelect":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDOMSelect.js","./ReactDOMTextarea":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDOMTextarea.js","./ReactDefaultBatchingStrategy":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDefaultBatchingStrategy.js","./ReactDefaultPerf":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDefaultPerf.js","./ReactEventListener":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactEventListener.js","./ReactInjection":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactInjection.js","./ReactInstanceHandles":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactInstanceHandles.js","./ReactMount":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactMount.js","./SVGDOMPropertyConfig":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SVGDOMPropertyConfig.js","./SelectEventPlugin":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SelectEventPlugin.js","./ServerReactRootIndex":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ServerReactRootIndex.js","./SimpleEventPlugin":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SimpleEventPlugin.js","./createFullPageComponent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/createFullPageComponent.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDefaultPerf.js":[function(require,module,exports){
+},{"./BeforeInputEventPlugin":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/BeforeInputEventPlugin.js","./ChangeEventPlugin":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ChangeEventPlugin.js","./ClientReactRootIndex":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ClientReactRootIndex.js","./CompositionEventPlugin":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/CompositionEventPlugin.js","./DefaultEventPluginOrder":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/DefaultEventPluginOrder.js","./EnterLeaveEventPlugin":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/EnterLeaveEventPlugin.js","./ExecutionEnvironment":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ExecutionEnvironment.js","./HTMLDOMPropertyConfig":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/HTMLDOMPropertyConfig.js","./MobileSafariClickEventPlugin":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/MobileSafariClickEventPlugin.js","./ReactBrowserComponentMixin":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactBrowserComponentMixin.js","./ReactComponentBrowserEnvironment":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactComponentBrowserEnvironment.js","./ReactDOM":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDOM.js","./ReactDOMButton":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDOMButton.js","./ReactDOMForm":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDOMForm.js","./ReactDOMImg":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDOMImg.js","./ReactDOMInput":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDOMInput.js","./ReactDOMOption":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDOMOption.js","./ReactDOMSelect":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDOMSelect.js","./ReactDOMTextarea":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDOMTextarea.js","./ReactDefaultBatchingStrategy":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDefaultBatchingStrategy.js","./ReactDefaultPerf":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDefaultPerf.js","./ReactEventListener":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactEventListener.js","./ReactInjection":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactInjection.js","./ReactInstanceHandles":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactInstanceHandles.js","./ReactMount":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactMount.js","./SVGDOMPropertyConfig":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SVGDOMPropertyConfig.js","./SelectEventPlugin":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SelectEventPlugin.js","./ServerReactRootIndex":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ServerReactRootIndex.js","./SimpleEventPlugin":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SimpleEventPlugin.js","./createFullPageComponent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/createFullPageComponent.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDefaultPerf.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -9350,7 +9361,7 @@ var ReactDefaultPerf = {
 
 module.exports = ReactDefaultPerf;
 
-},{"./DOMProperty":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/DOMProperty.js","./ReactDefaultPerfAnalysis":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDefaultPerfAnalysis.js","./ReactMount":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactMount.js","./ReactPerf":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactPerf.js","./performanceNow":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/performanceNow.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDefaultPerfAnalysis.js":[function(require,module,exports){
+},{"./DOMProperty":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/DOMProperty.js","./ReactDefaultPerfAnalysis":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDefaultPerfAnalysis.js","./ReactMount":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactMount.js","./ReactPerf":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactPerf.js","./performanceNow":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/performanceNow.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDefaultPerfAnalysis.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -9555,7 +9566,7 @@ var ReactDefaultPerfAnalysis = {
 
 module.exports = ReactDefaultPerfAnalysis;
 
-},{"./merge":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/merge.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDescriptor.js":[function(require,module,exports){
+},{"./merge":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/merge.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDescriptor.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2014 Facebook, Inc.
@@ -9810,7 +9821,7 @@ ReactDescriptor.isValidDescriptor = function(object) {
 module.exports = ReactDescriptor;
 
 }).call(this,require('_process'))
-},{"./ReactContext":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactContext.js","./ReactCurrentOwner":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactCurrentOwner.js","./merge":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/merge.js","./warning":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/warning.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDescriptorValidator.js":[function(require,module,exports){
+},{"./ReactContext":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactContext.js","./ReactCurrentOwner":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactCurrentOwner.js","./merge":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/merge.js","./warning":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/warning.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDescriptorValidator.js":[function(require,module,exports){
 /**
  * Copyright 2014 Facebook, Inc.
  *
@@ -10095,7 +10106,7 @@ var ReactDescriptorValidator = {
 
 module.exports = ReactDescriptorValidator;
 
-},{"./ReactCurrentOwner":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactCurrentOwner.js","./ReactDescriptor":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDescriptor.js","./ReactPropTypeLocations":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactPropTypeLocations.js","./monitorCodeUse":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/monitorCodeUse.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactEmptyComponent.js":[function(require,module,exports){
+},{"./ReactCurrentOwner":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactCurrentOwner.js","./ReactDescriptor":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDescriptor.js","./ReactPropTypeLocations":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactPropTypeLocations.js","./monitorCodeUse":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/monitorCodeUse.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactEmptyComponent.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2014 Facebook, Inc.
@@ -10177,7 +10188,7 @@ var ReactEmptyComponent = {
 module.exports = ReactEmptyComponent;
 
 }).call(this,require('_process'))
-},{"./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactErrorUtils.js":[function(require,module,exports){
+},{"./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactErrorUtils.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -10216,7 +10227,7 @@ var ReactErrorUtils = {
 
 module.exports = ReactErrorUtils;
 
-},{}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactEventEmitterMixin.js":[function(require,module,exports){
+},{}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactEventEmitterMixin.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -10273,7 +10284,7 @@ var ReactEventEmitterMixin = {
 
 module.exports = ReactEventEmitterMixin;
 
-},{"./EventPluginHub":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/EventPluginHub.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactEventListener.js":[function(require,module,exports){
+},{"./EventPluginHub":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/EventPluginHub.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactEventListener.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -10464,7 +10475,7 @@ var ReactEventListener = {
 
 module.exports = ReactEventListener;
 
-},{"./EventListener":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/EventListener.js","./ExecutionEnvironment":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ExecutionEnvironment.js","./PooledClass":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/PooledClass.js","./ReactInstanceHandles":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactInstanceHandles.js","./ReactMount":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactMount.js","./ReactUpdates":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactUpdates.js","./getEventTarget":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/getEventTarget.js","./getUnboundedScrollPosition":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/getUnboundedScrollPosition.js","./mixInto":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/mixInto.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactInjection.js":[function(require,module,exports){
+},{"./EventListener":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/EventListener.js","./ExecutionEnvironment":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ExecutionEnvironment.js","./PooledClass":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/PooledClass.js","./ReactInstanceHandles":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactInstanceHandles.js","./ReactMount":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactMount.js","./ReactUpdates":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactUpdates.js","./getEventTarget":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/getEventTarget.js","./getUnboundedScrollPosition":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/getUnboundedScrollPosition.js","./mixInto":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/mixInto.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactInjection.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -10511,7 +10522,7 @@ var ReactInjection = {
 
 module.exports = ReactInjection;
 
-},{"./DOMProperty":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/DOMProperty.js","./EventPluginHub":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/EventPluginHub.js","./ReactBrowserEventEmitter":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactBrowserEventEmitter.js","./ReactComponent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactComponent.js","./ReactCompositeComponent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactCompositeComponent.js","./ReactDOM":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDOM.js","./ReactEmptyComponent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactEmptyComponent.js","./ReactPerf":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactPerf.js","./ReactRootIndex":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactRootIndex.js","./ReactUpdates":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactUpdates.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactInputSelection.js":[function(require,module,exports){
+},{"./DOMProperty":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/DOMProperty.js","./EventPluginHub":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/EventPluginHub.js","./ReactBrowserEventEmitter":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactBrowserEventEmitter.js","./ReactComponent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactComponent.js","./ReactCompositeComponent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactCompositeComponent.js","./ReactDOM":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDOM.js","./ReactEmptyComponent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactEmptyComponent.js","./ReactPerf":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactPerf.js","./ReactRootIndex":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactRootIndex.js","./ReactUpdates":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactUpdates.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactInputSelection.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -10654,7 +10665,7 @@ var ReactInputSelection = {
 
 module.exports = ReactInputSelection;
 
-},{"./ReactDOMSelection":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDOMSelection.js","./containsNode":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/containsNode.js","./focusNode":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/focusNode.js","./getActiveElement":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/getActiveElement.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactInstanceHandles.js":[function(require,module,exports){
+},{"./ReactDOMSelection":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDOMSelection.js","./containsNode":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/containsNode.js","./focusNode":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/focusNode.js","./getActiveElement":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/getActiveElement.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactInstanceHandles.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -10996,7 +11007,7 @@ var ReactInstanceHandles = {
 module.exports = ReactInstanceHandles;
 
 }).call(this,require('_process'))
-},{"./ReactRootIndex":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactRootIndex.js","./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactMarkupChecksum.js":[function(require,module,exports){
+},{"./ReactRootIndex":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactRootIndex.js","./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactMarkupChecksum.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -11051,7 +11062,7 @@ var ReactMarkupChecksum = {
 
 module.exports = ReactMarkupChecksum;
 
-},{"./adler32":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/adler32.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactMount.js":[function(require,module,exports){
+},{"./adler32":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/adler32.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactMount.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -11736,7 +11747,7 @@ var ReactMount = {
 module.exports = ReactMount;
 
 }).call(this,require('_process'))
-},{"./DOMProperty":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/DOMProperty.js","./ReactBrowserEventEmitter":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactBrowserEventEmitter.js","./ReactCurrentOwner":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactCurrentOwner.js","./ReactDescriptor":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDescriptor.js","./ReactInstanceHandles":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactInstanceHandles.js","./ReactPerf":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactPerf.js","./containsNode":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/containsNode.js","./getReactRootElementInContainer":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/getReactRootElementInContainer.js","./instantiateReactComponent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/instantiateReactComponent.js","./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","./shouldUpdateReactComponent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/shouldUpdateReactComponent.js","./warning":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/warning.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactMultiChild.js":[function(require,module,exports){
+},{"./DOMProperty":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/DOMProperty.js","./ReactBrowserEventEmitter":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactBrowserEventEmitter.js","./ReactCurrentOwner":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactCurrentOwner.js","./ReactDescriptor":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDescriptor.js","./ReactInstanceHandles":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactInstanceHandles.js","./ReactPerf":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactPerf.js","./containsNode":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/containsNode.js","./getReactRootElementInContainer":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/getReactRootElementInContainer.js","./instantiateReactComponent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/instantiateReactComponent.js","./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","./shouldUpdateReactComponent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/shouldUpdateReactComponent.js","./warning":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/warning.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactMultiChild.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -12168,7 +12179,7 @@ var ReactMultiChild = {
 
 module.exports = ReactMultiChild;
 
-},{"./ReactComponent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactComponent.js","./ReactMultiChildUpdateTypes":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactMultiChildUpdateTypes.js","./flattenChildren":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/flattenChildren.js","./instantiateReactComponent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/instantiateReactComponent.js","./shouldUpdateReactComponent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/shouldUpdateReactComponent.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactMultiChildUpdateTypes.js":[function(require,module,exports){
+},{"./ReactComponent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactComponent.js","./ReactMultiChildUpdateTypes":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactMultiChildUpdateTypes.js","./flattenChildren":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/flattenChildren.js","./instantiateReactComponent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/instantiateReactComponent.js","./shouldUpdateReactComponent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/shouldUpdateReactComponent.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactMultiChildUpdateTypes.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -12208,7 +12219,7 @@ var ReactMultiChildUpdateTypes = keyMirror({
 
 module.exports = ReactMultiChildUpdateTypes;
 
-},{"./keyMirror":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/keyMirror.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactOwner.js":[function(require,module,exports){
+},{"./keyMirror":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/keyMirror.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactOwner.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -12371,7 +12382,7 @@ var ReactOwner = {
 module.exports = ReactOwner;
 
 }).call(this,require('_process'))
-},{"./emptyObject":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/emptyObject.js","./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactPerf.js":[function(require,module,exports){
+},{"./emptyObject":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/emptyObject.js","./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactPerf.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -12460,7 +12471,7 @@ function _noMeasure(objName, fnName, func) {
 module.exports = ReactPerf;
 
 }).call(this,require('_process'))
-},{"_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactPropTransferer.js":[function(require,module,exports){
+},{"_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactPropTransferer.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -12626,7 +12637,7 @@ var ReactPropTransferer = {
 module.exports = ReactPropTransferer;
 
 }).call(this,require('_process'))
-},{"./emptyFunction":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/emptyFunction.js","./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","./joinClasses":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/joinClasses.js","./merge":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/merge.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactPropTypeLocationNames.js":[function(require,module,exports){
+},{"./emptyFunction":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/emptyFunction.js","./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","./joinClasses":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/joinClasses.js","./merge":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/merge.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactPropTypeLocationNames.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -12661,7 +12672,7 @@ if ("production" !== process.env.NODE_ENV) {
 module.exports = ReactPropTypeLocationNames;
 
 }).call(this,require('_process'))
-},{"_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactPropTypeLocations.js":[function(require,module,exports){
+},{"_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactPropTypeLocations.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -12692,7 +12703,7 @@ var ReactPropTypeLocations = keyMirror({
 
 module.exports = ReactPropTypeLocations;
 
-},{"./keyMirror":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/keyMirror.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactPropTypes.js":[function(require,module,exports){
+},{"./keyMirror":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/keyMirror.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactPropTypes.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -13037,7 +13048,7 @@ function getPreciseType(propValue) {
 
 module.exports = ReactPropTypes;
 
-},{"./ReactDescriptor":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDescriptor.js","./ReactPropTypeLocationNames":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactPropTypeLocationNames.js","./emptyFunction":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/emptyFunction.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactPutListenerQueue.js":[function(require,module,exports){
+},{"./ReactDescriptor":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDescriptor.js","./ReactPropTypeLocationNames":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactPropTypeLocationNames.js","./emptyFunction":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/emptyFunction.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactPutListenerQueue.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -13100,7 +13111,7 @@ PooledClass.addPoolingTo(ReactPutListenerQueue);
 
 module.exports = ReactPutListenerQueue;
 
-},{"./PooledClass":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/PooledClass.js","./ReactBrowserEventEmitter":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactBrowserEventEmitter.js","./mixInto":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/mixInto.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactReconcileTransaction.js":[function(require,module,exports){
+},{"./PooledClass":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/PooledClass.js","./ReactBrowserEventEmitter":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactBrowserEventEmitter.js","./mixInto":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/mixInto.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactReconcileTransaction.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -13284,7 +13295,7 @@ PooledClass.addPoolingTo(ReactReconcileTransaction);
 
 module.exports = ReactReconcileTransaction;
 
-},{"./CallbackQueue":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/CallbackQueue.js","./PooledClass":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/PooledClass.js","./ReactBrowserEventEmitter":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactBrowserEventEmitter.js","./ReactInputSelection":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactInputSelection.js","./ReactPutListenerQueue":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactPutListenerQueue.js","./Transaction":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/Transaction.js","./mixInto":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/mixInto.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactRootIndex.js":[function(require,module,exports){
+},{"./CallbackQueue":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/CallbackQueue.js","./PooledClass":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/PooledClass.js","./ReactBrowserEventEmitter":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactBrowserEventEmitter.js","./ReactInputSelection":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactInputSelection.js","./ReactPutListenerQueue":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactPutListenerQueue.js","./Transaction":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/Transaction.js","./mixInto":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/mixInto.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactRootIndex.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -13322,7 +13333,7 @@ var ReactRootIndex = {
 
 module.exports = ReactRootIndex;
 
-},{}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactServerRendering.js":[function(require,module,exports){
+},{}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactServerRendering.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -13415,7 +13426,7 @@ module.exports = {
 };
 
 }).call(this,require('_process'))
-},{"./ReactDescriptor":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDescriptor.js","./ReactInstanceHandles":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactInstanceHandles.js","./ReactMarkupChecksum":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactMarkupChecksum.js","./ReactServerRenderingTransaction":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactServerRenderingTransaction.js","./instantiateReactComponent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/instantiateReactComponent.js","./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactServerRenderingTransaction.js":[function(require,module,exports){
+},{"./ReactDescriptor":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDescriptor.js","./ReactInstanceHandles":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactInstanceHandles.js","./ReactMarkupChecksum":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactMarkupChecksum.js","./ReactServerRenderingTransaction":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactServerRenderingTransaction.js","./instantiateReactComponent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/instantiateReactComponent.js","./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactServerRenderingTransaction.js":[function(require,module,exports){
 /**
  * Copyright 2014 Facebook, Inc.
  *
@@ -13532,7 +13543,7 @@ PooledClass.addPoolingTo(ReactServerRenderingTransaction);
 
 module.exports = ReactServerRenderingTransaction;
 
-},{"./CallbackQueue":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/CallbackQueue.js","./PooledClass":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/PooledClass.js","./ReactPutListenerQueue":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactPutListenerQueue.js","./Transaction":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/Transaction.js","./emptyFunction":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/emptyFunction.js","./mixInto":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/mixInto.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactTextComponent.js":[function(require,module,exports){
+},{"./CallbackQueue":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/CallbackQueue.js","./PooledClass":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/PooledClass.js","./ReactPutListenerQueue":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactPutListenerQueue.js","./Transaction":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/Transaction.js","./emptyFunction":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/emptyFunction.js","./mixInto":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/mixInto.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactTextComponent.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -13641,7 +13652,7 @@ mixInto(ReactTextComponent, {
 
 module.exports = ReactDescriptor.createFactory(ReactTextComponent);
 
-},{"./DOMPropertyOperations":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/DOMPropertyOperations.js","./ReactBrowserComponentMixin":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactBrowserComponentMixin.js","./ReactComponent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactComponent.js","./ReactDescriptor":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDescriptor.js","./escapeTextForBrowser":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/escapeTextForBrowser.js","./mixInto":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/mixInto.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactUpdates.js":[function(require,module,exports){
+},{"./DOMPropertyOperations":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/DOMPropertyOperations.js","./ReactBrowserComponentMixin":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactBrowserComponentMixin.js","./ReactComponent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactComponent.js","./ReactDescriptor":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDescriptor.js","./escapeTextForBrowser":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/escapeTextForBrowser.js","./mixInto":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/mixInto.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactUpdates.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -13910,7 +13921,7 @@ var ReactUpdates = {
 module.exports = ReactUpdates;
 
 }).call(this,require('_process'))
-},{"./CallbackQueue":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/CallbackQueue.js","./PooledClass":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/PooledClass.js","./ReactCurrentOwner":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactCurrentOwner.js","./ReactPerf":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactPerf.js","./Transaction":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/Transaction.js","./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","./mixInto":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/mixInto.js","./warning":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/warning.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SVGDOMPropertyConfig.js":[function(require,module,exports){
+},{"./CallbackQueue":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/CallbackQueue.js","./PooledClass":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/PooledClass.js","./ReactCurrentOwner":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactCurrentOwner.js","./ReactPerf":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactPerf.js","./Transaction":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/Transaction.js","./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","./mixInto":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/mixInto.js","./warning":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/warning.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SVGDOMPropertyConfig.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -14009,7 +14020,7 @@ var SVGDOMPropertyConfig = {
 
 module.exports = SVGDOMPropertyConfig;
 
-},{"./DOMProperty":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/DOMProperty.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SelectEventPlugin.js":[function(require,module,exports){
+},{"./DOMProperty":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/DOMProperty.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SelectEventPlugin.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -14211,7 +14222,7 @@ var SelectEventPlugin = {
 
 module.exports = SelectEventPlugin;
 
-},{"./EventConstants":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/EventConstants.js","./EventPropagators":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/EventPropagators.js","./ReactInputSelection":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactInputSelection.js","./SyntheticEvent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SyntheticEvent.js","./getActiveElement":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/getActiveElement.js","./isTextInputElement":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/isTextInputElement.js","./keyOf":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/keyOf.js","./shallowEqual":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/shallowEqual.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ServerReactRootIndex.js":[function(require,module,exports){
+},{"./EventConstants":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/EventConstants.js","./EventPropagators":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/EventPropagators.js","./ReactInputSelection":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactInputSelection.js","./SyntheticEvent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SyntheticEvent.js","./getActiveElement":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/getActiveElement.js","./isTextInputElement":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/isTextInputElement.js","./keyOf":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/keyOf.js","./shallowEqual":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/shallowEqual.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ServerReactRootIndex.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -14249,7 +14260,7 @@ var ServerReactRootIndex = {
 
 module.exports = ServerReactRootIndex;
 
-},{}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SimpleEventPlugin.js":[function(require,module,exports){
+},{}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SimpleEventPlugin.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -14672,7 +14683,7 @@ var SimpleEventPlugin = {
 module.exports = SimpleEventPlugin;
 
 }).call(this,require('_process'))
-},{"./EventConstants":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/EventConstants.js","./EventPluginUtils":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/EventPluginUtils.js","./EventPropagators":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/EventPropagators.js","./SyntheticClipboardEvent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SyntheticClipboardEvent.js","./SyntheticDragEvent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SyntheticDragEvent.js","./SyntheticEvent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SyntheticEvent.js","./SyntheticFocusEvent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SyntheticFocusEvent.js","./SyntheticKeyboardEvent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SyntheticKeyboardEvent.js","./SyntheticMouseEvent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SyntheticMouseEvent.js","./SyntheticTouchEvent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SyntheticTouchEvent.js","./SyntheticUIEvent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SyntheticUIEvent.js","./SyntheticWheelEvent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SyntheticWheelEvent.js","./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","./keyOf":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/keyOf.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SyntheticClipboardEvent.js":[function(require,module,exports){
+},{"./EventConstants":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/EventConstants.js","./EventPluginUtils":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/EventPluginUtils.js","./EventPropagators":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/EventPropagators.js","./SyntheticClipboardEvent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SyntheticClipboardEvent.js","./SyntheticDragEvent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SyntheticDragEvent.js","./SyntheticEvent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SyntheticEvent.js","./SyntheticFocusEvent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SyntheticFocusEvent.js","./SyntheticKeyboardEvent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SyntheticKeyboardEvent.js","./SyntheticMouseEvent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SyntheticMouseEvent.js","./SyntheticTouchEvent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SyntheticTouchEvent.js","./SyntheticUIEvent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SyntheticUIEvent.js","./SyntheticWheelEvent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SyntheticWheelEvent.js","./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","./keyOf":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/keyOf.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SyntheticClipboardEvent.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -14725,7 +14736,7 @@ SyntheticEvent.augmentClass(SyntheticClipboardEvent, ClipboardEventInterface);
 module.exports = SyntheticClipboardEvent;
 
 
-},{"./SyntheticEvent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SyntheticEvent.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SyntheticCompositionEvent.js":[function(require,module,exports){
+},{"./SyntheticEvent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SyntheticEvent.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SyntheticCompositionEvent.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -14778,7 +14789,7 @@ SyntheticEvent.augmentClass(
 module.exports = SyntheticCompositionEvent;
 
 
-},{"./SyntheticEvent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SyntheticEvent.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SyntheticDragEvent.js":[function(require,module,exports){
+},{"./SyntheticEvent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SyntheticEvent.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SyntheticDragEvent.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -14824,7 +14835,7 @@ SyntheticMouseEvent.augmentClass(SyntheticDragEvent, DragEventInterface);
 
 module.exports = SyntheticDragEvent;
 
-},{"./SyntheticMouseEvent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SyntheticMouseEvent.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SyntheticEvent.js":[function(require,module,exports){
+},{"./SyntheticMouseEvent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SyntheticMouseEvent.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SyntheticEvent.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -14990,7 +15001,7 @@ PooledClass.addPoolingTo(SyntheticEvent, PooledClass.threeArgumentPooler);
 
 module.exports = SyntheticEvent;
 
-},{"./PooledClass":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/PooledClass.js","./emptyFunction":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/emptyFunction.js","./getEventTarget":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/getEventTarget.js","./merge":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/merge.js","./mergeInto":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/mergeInto.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SyntheticFocusEvent.js":[function(require,module,exports){
+},{"./PooledClass":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/PooledClass.js","./emptyFunction":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/emptyFunction.js","./getEventTarget":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/getEventTarget.js","./merge":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/merge.js","./mergeInto":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/mergeInto.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SyntheticFocusEvent.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -15036,7 +15047,7 @@ SyntheticUIEvent.augmentClass(SyntheticFocusEvent, FocusEventInterface);
 
 module.exports = SyntheticFocusEvent;
 
-},{"./SyntheticUIEvent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SyntheticUIEvent.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SyntheticInputEvent.js":[function(require,module,exports){
+},{"./SyntheticUIEvent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SyntheticUIEvent.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SyntheticInputEvent.js":[function(require,module,exports){
 /**
  * Copyright 2013 Facebook, Inc.
  *
@@ -15090,7 +15101,7 @@ SyntheticEvent.augmentClass(
 module.exports = SyntheticInputEvent;
 
 
-},{"./SyntheticEvent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SyntheticEvent.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SyntheticKeyboardEvent.js":[function(require,module,exports){
+},{"./SyntheticEvent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SyntheticEvent.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SyntheticKeyboardEvent.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -15179,7 +15190,7 @@ SyntheticUIEvent.augmentClass(SyntheticKeyboardEvent, KeyboardEventInterface);
 
 module.exports = SyntheticKeyboardEvent;
 
-},{"./SyntheticUIEvent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SyntheticUIEvent.js","./getEventKey":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/getEventKey.js","./getEventModifierState":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/getEventModifierState.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SyntheticMouseEvent.js":[function(require,module,exports){
+},{"./SyntheticUIEvent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SyntheticUIEvent.js","./getEventKey":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/getEventKey.js","./getEventModifierState":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/getEventModifierState.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SyntheticMouseEvent.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -15269,7 +15280,7 @@ SyntheticUIEvent.augmentClass(SyntheticMouseEvent, MouseEventInterface);
 
 module.exports = SyntheticMouseEvent;
 
-},{"./SyntheticUIEvent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SyntheticUIEvent.js","./ViewportMetrics":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ViewportMetrics.js","./getEventModifierState":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/getEventModifierState.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SyntheticTouchEvent.js":[function(require,module,exports){
+},{"./SyntheticUIEvent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SyntheticUIEvent.js","./ViewportMetrics":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ViewportMetrics.js","./getEventModifierState":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/getEventModifierState.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SyntheticTouchEvent.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -15324,7 +15335,7 @@ SyntheticUIEvent.augmentClass(SyntheticTouchEvent, TouchEventInterface);
 
 module.exports = SyntheticTouchEvent;
 
-},{"./SyntheticUIEvent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SyntheticUIEvent.js","./getEventModifierState":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/getEventModifierState.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SyntheticUIEvent.js":[function(require,module,exports){
+},{"./SyntheticUIEvent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SyntheticUIEvent.js","./getEventModifierState":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/getEventModifierState.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SyntheticUIEvent.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -15393,7 +15404,7 @@ SyntheticEvent.augmentClass(SyntheticUIEvent, UIEventInterface);
 
 module.exports = SyntheticUIEvent;
 
-},{"./SyntheticEvent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SyntheticEvent.js","./getEventTarget":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/getEventTarget.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SyntheticWheelEvent.js":[function(require,module,exports){
+},{"./SyntheticEvent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SyntheticEvent.js","./getEventTarget":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/getEventTarget.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SyntheticWheelEvent.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -15461,7 +15472,7 @@ SyntheticMouseEvent.augmentClass(SyntheticWheelEvent, WheelEventInterface);
 
 module.exports = SyntheticWheelEvent;
 
-},{"./SyntheticMouseEvent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/SyntheticMouseEvent.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/Transaction.js":[function(require,module,exports){
+},{"./SyntheticMouseEvent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/SyntheticMouseEvent.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/Transaction.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -15709,7 +15720,7 @@ var Transaction = {
 module.exports = Transaction;
 
 }).call(this,require('_process'))
-},{"./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ViewportMetrics.js":[function(require,module,exports){
+},{"./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ViewportMetrics.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -15748,7 +15759,7 @@ var ViewportMetrics = {
 
 module.exports = ViewportMetrics;
 
-},{"./getUnboundedScrollPosition":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/getUnboundedScrollPosition.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/accumulate.js":[function(require,module,exports){
+},{"./getUnboundedScrollPosition":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/getUnboundedScrollPosition.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/accumulate.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -15806,7 +15817,7 @@ function accumulate(current, next) {
 module.exports = accumulate;
 
 }).call(this,require('_process'))
-},{"./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/adler32.js":[function(require,module,exports){
+},{"./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/adler32.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -15847,7 +15858,7 @@ function adler32(data) {
 
 module.exports = adler32;
 
-},{}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/containsNode.js":[function(require,module,exports){
+},{}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/containsNode.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -15898,7 +15909,7 @@ function containsNode(outerNode, innerNode) {
 
 module.exports = containsNode;
 
-},{"./isTextNode":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/isTextNode.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/copyProperties.js":[function(require,module,exports){
+},{"./isTextNode":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/isTextNode.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/copyProperties.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -15956,7 +15967,7 @@ function copyProperties(obj, a, b, c, d, e, f) {
 module.exports = copyProperties;
 
 }).call(this,require('_process'))
-},{"_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/createArrayFrom.js":[function(require,module,exports){
+},{"_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/createArrayFrom.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -16049,7 +16060,7 @@ function createArrayFrom(obj) {
 
 module.exports = createArrayFrom;
 
-},{"./toArray":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/toArray.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/createFullPageComponent.js":[function(require,module,exports){
+},{"./toArray":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/toArray.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/createFullPageComponent.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -16116,7 +16127,7 @@ function createFullPageComponent(componentClass) {
 module.exports = createFullPageComponent;
 
 }).call(this,require('_process'))
-},{"./ReactCompositeComponent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactCompositeComponent.js","./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/createNodesFromMarkup.js":[function(require,module,exports){
+},{"./ReactCompositeComponent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactCompositeComponent.js","./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/createNodesFromMarkup.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -16213,7 +16224,7 @@ function createNodesFromMarkup(markup, handleScript) {
 module.exports = createNodesFromMarkup;
 
 }).call(this,require('_process'))
-},{"./ExecutionEnvironment":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ExecutionEnvironment.js","./createArrayFrom":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/createArrayFrom.js","./getMarkupWrap":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/getMarkupWrap.js","./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/dangerousStyleValue.js":[function(require,module,exports){
+},{"./ExecutionEnvironment":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ExecutionEnvironment.js","./createArrayFrom":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/createArrayFrom.js","./getMarkupWrap":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/getMarkupWrap.js","./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/dangerousStyleValue.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -16278,7 +16289,7 @@ function dangerousStyleValue(name, value) {
 
 module.exports = dangerousStyleValue;
 
-},{"./CSSProperty":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/CSSProperty.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/emptyFunction.js":[function(require,module,exports){
+},{"./CSSProperty":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/CSSProperty.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/emptyFunction.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -16323,7 +16334,7 @@ copyProperties(emptyFunction, {
 
 module.exports = emptyFunction;
 
-},{"./copyProperties":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/copyProperties.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/emptyObject.js":[function(require,module,exports){
+},{"./copyProperties":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/copyProperties.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/emptyObject.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -16354,7 +16365,7 @@ if ("production" !== process.env.NODE_ENV) {
 module.exports = emptyObject;
 
 }).call(this,require('_process'))
-},{"_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/escapeTextForBrowser.js":[function(require,module,exports){
+},{"_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/escapeTextForBrowser.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -16402,7 +16413,7 @@ function escapeTextForBrowser(text) {
 
 module.exports = escapeTextForBrowser;
 
-},{}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/flattenChildren.js":[function(require,module,exports){
+},{}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/flattenChildren.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -16465,7 +16476,7 @@ function flattenChildren(children) {
 module.exports = flattenChildren;
 
 }).call(this,require('_process'))
-},{"./traverseAllChildren":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/traverseAllChildren.js","./warning":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/warning.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/focusNode.js":[function(require,module,exports){
+},{"./traverseAllChildren":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/traverseAllChildren.js","./warning":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/warning.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/focusNode.js":[function(require,module,exports){
 /**
  * Copyright 2014 Facebook, Inc.
  *
@@ -16500,7 +16511,7 @@ function focusNode(node) {
 
 module.exports = focusNode;
 
-},{}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/forEachAccumulated.js":[function(require,module,exports){
+},{}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/forEachAccumulated.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -16538,7 +16549,7 @@ var forEachAccumulated = function(arr, cb, scope) {
 
 module.exports = forEachAccumulated;
 
-},{}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/getActiveElement.js":[function(require,module,exports){
+},{}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/getActiveElement.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -16574,7 +16585,7 @@ function getActiveElement() /*?DOMElement*/ {
 
 module.exports = getActiveElement;
 
-},{}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/getEventKey.js":[function(require,module,exports){
+},{}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/getEventKey.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -16693,7 +16704,7 @@ function getEventKey(nativeEvent) {
 module.exports = getEventKey;
 
 }).call(this,require('_process'))
-},{"./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/getEventModifierState.js":[function(require,module,exports){
+},{"./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/getEventModifierState.js":[function(require,module,exports){
 /**
  * Copyright 2013 Facebook, Inc.
  *
@@ -16747,7 +16758,7 @@ function getEventModifierState(nativeEvent) {
 
 module.exports = getEventModifierState;
 
-},{}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/getEventTarget.js":[function(require,module,exports){
+},{}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/getEventTarget.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -16785,7 +16796,7 @@ function getEventTarget(nativeEvent) {
 
 module.exports = getEventTarget;
 
-},{}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/getMarkupWrap.js":[function(require,module,exports){
+},{}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/getMarkupWrap.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -16909,7 +16920,7 @@ function getMarkupWrap(nodeName) {
 module.exports = getMarkupWrap;
 
 }).call(this,require('_process'))
-},{"./ExecutionEnvironment":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ExecutionEnvironment.js","./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/getNodeForCharacterOffset.js":[function(require,module,exports){
+},{"./ExecutionEnvironment":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ExecutionEnvironment.js","./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/getNodeForCharacterOffset.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -16991,7 +17002,7 @@ function getNodeForCharacterOffset(root, offset) {
 
 module.exports = getNodeForCharacterOffset;
 
-},{}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/getReactRootElementInContainer.js":[function(require,module,exports){
+},{}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/getReactRootElementInContainer.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -17033,7 +17044,7 @@ function getReactRootElementInContainer(container) {
 
 module.exports = getReactRootElementInContainer;
 
-},{}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/getTextContentAccessor.js":[function(require,module,exports){
+},{}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/getTextContentAccessor.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -17077,7 +17088,7 @@ function getTextContentAccessor() {
 
 module.exports = getTextContentAccessor;
 
-},{"./ExecutionEnvironment":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ExecutionEnvironment.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/getUnboundedScrollPosition.js":[function(require,module,exports){
+},{"./ExecutionEnvironment":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ExecutionEnvironment.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/getUnboundedScrollPosition.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -17124,7 +17135,7 @@ function getUnboundedScrollPosition(scrollable) {
 
 module.exports = getUnboundedScrollPosition;
 
-},{}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/hyphenate.js":[function(require,module,exports){
+},{}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/hyphenate.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -17164,7 +17175,7 @@ function hyphenate(string) {
 
 module.exports = hyphenate;
 
-},{}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/hyphenateStyleName.js":[function(require,module,exports){
+},{}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/hyphenateStyleName.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -17212,7 +17223,7 @@ function hyphenateStyleName(string) {
 
 module.exports = hyphenateStyleName;
 
-},{"./hyphenate":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/hyphenate.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/instantiateReactComponent.js":[function(require,module,exports){
+},{"./hyphenate":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/hyphenate.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/instantiateReactComponent.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -17278,7 +17289,7 @@ function instantiateReactComponent(descriptor) {
 module.exports = instantiateReactComponent;
 
 }).call(this,require('_process'))
-},{"./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js":[function(require,module,exports){
+},{"./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -17342,7 +17353,7 @@ var invariant = function(condition, format, a, b, c, d, e, f) {
 module.exports = invariant;
 
 }).call(this,require('_process'))
-},{"_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/isEventSupported.js":[function(require,module,exports){
+},{"_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/isEventSupported.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -17414,7 +17425,7 @@ function isEventSupported(eventNameSuffix, capture) {
 
 module.exports = isEventSupported;
 
-},{"./ExecutionEnvironment":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ExecutionEnvironment.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/isNode.js":[function(require,module,exports){
+},{"./ExecutionEnvironment":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ExecutionEnvironment.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/isNode.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -17449,7 +17460,7 @@ function isNode(object) {
 
 module.exports = isNode;
 
-},{}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/isTextInputElement.js":[function(require,module,exports){
+},{}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/isTextInputElement.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -17500,7 +17511,7 @@ function isTextInputElement(elem) {
 
 module.exports = isTextInputElement;
 
-},{}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/isTextNode.js":[function(require,module,exports){
+},{}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/isTextNode.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -17532,7 +17543,7 @@ function isTextNode(object) {
 
 module.exports = isTextNode;
 
-},{"./isNode":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/isNode.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/joinClasses.js":[function(require,module,exports){
+},{"./isNode":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/isNode.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/joinClasses.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -17578,7 +17589,7 @@ function joinClasses(className/*, ... */) {
 
 module.exports = joinClasses;
 
-},{}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/keyMirror.js":[function(require,module,exports){
+},{}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/keyMirror.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -17640,7 +17651,7 @@ var keyMirror = function(obj) {
 module.exports = keyMirror;
 
 }).call(this,require('_process'))
-},{"./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/keyOf.js":[function(require,module,exports){
+},{"./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/keyOf.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -17683,7 +17694,7 @@ var keyOf = function(oneKeyObj) {
 
 module.exports = keyOf;
 
-},{}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/mapObject.js":[function(require,module,exports){
+},{}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/mapObject.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -17737,7 +17748,7 @@ function mapObject(obj, func, context) {
 
 module.exports = mapObject;
 
-},{}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/memoizeStringOnly.js":[function(require,module,exports){
+},{}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/memoizeStringOnly.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -17778,7 +17789,7 @@ function memoizeStringOnly(callback) {
 
 module.exports = memoizeStringOnly;
 
-},{}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/merge.js":[function(require,module,exports){
+},{}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/merge.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -17817,7 +17828,7 @@ var merge = function(one, two) {
 
 module.exports = merge;
 
-},{"./mergeInto":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/mergeInto.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/mergeHelpers.js":[function(require,module,exports){
+},{"./mergeInto":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/mergeInto.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/mergeHelpers.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -17968,7 +17979,7 @@ var mergeHelpers = {
 module.exports = mergeHelpers;
 
 }).call(this,require('_process'))
-},{"./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","./keyMirror":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/keyMirror.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/mergeInto.js":[function(require,module,exports){
+},{"./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","./keyMirror":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/keyMirror.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/mergeInto.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -18016,7 +18027,7 @@ function mergeInto(one, two) {
 
 module.exports = mergeInto;
 
-},{"./mergeHelpers":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/mergeHelpers.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/mixInto.js":[function(require,module,exports){
+},{"./mergeHelpers":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/mergeHelpers.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/mixInto.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -18052,7 +18063,7 @@ var mixInto = function(constructor, methodBag) {
 
 module.exports = mixInto;
 
-},{}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/monitorCodeUse.js":[function(require,module,exports){
+},{}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/monitorCodeUse.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2014 Facebook, Inc.
@@ -18093,7 +18104,7 @@ function monitorCodeUse(eventName, data) {
 module.exports = monitorCodeUse;
 
 }).call(this,require('_process'))
-},{"./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/onlyChild.js":[function(require,module,exports){
+},{"./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/onlyChild.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -18140,7 +18151,7 @@ function onlyChild(children) {
 module.exports = onlyChild;
 
 }).call(this,require('_process'))
-},{"./ReactDescriptor":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactDescriptor.js","./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/performance.js":[function(require,module,exports){
+},{"./ReactDescriptor":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactDescriptor.js","./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/performance.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -18175,7 +18186,7 @@ if (ExecutionEnvironment.canUseDOM) {
 
 module.exports = performance || {};
 
-},{"./ExecutionEnvironment":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ExecutionEnvironment.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/performanceNow.js":[function(require,module,exports){
+},{"./ExecutionEnvironment":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ExecutionEnvironment.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/performanceNow.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -18210,7 +18221,7 @@ var performanceNow = performance.now.bind(performance);
 
 module.exports = performanceNow;
 
-},{"./performance":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/performance.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/setInnerHTML.js":[function(require,module,exports){
+},{"./performance":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/performance.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/setInnerHTML.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -18297,7 +18308,7 @@ if (ExecutionEnvironment.canUseDOM) {
 
 module.exports = setInnerHTML;
 
-},{"./ExecutionEnvironment":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ExecutionEnvironment.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/shallowEqual.js":[function(require,module,exports){
+},{"./ExecutionEnvironment":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ExecutionEnvironment.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/shallowEqual.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -18348,7 +18359,7 @@ function shallowEqual(objA, objB) {
 
 module.exports = shallowEqual;
 
-},{}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/shouldUpdateReactComponent.js":[function(require,module,exports){
+},{}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/shouldUpdateReactComponent.js":[function(require,module,exports){
 /**
  * Copyright 2013-2014 Facebook, Inc.
  *
@@ -18394,7 +18405,7 @@ function shouldUpdateReactComponent(prevDescriptor, nextDescriptor) {
 
 module.exports = shouldUpdateReactComponent;
 
-},{}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/toArray.js":[function(require,module,exports){
+},{}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/toArray.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2014 Facebook, Inc.
@@ -18473,7 +18484,7 @@ function toArray(obj) {
 module.exports = toArray;
 
 }).call(this,require('_process'))
-},{"./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/traverseAllChildren.js":[function(require,module,exports){
+},{"./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/traverseAllChildren.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2013-2014 Facebook, Inc.
@@ -18670,7 +18681,7 @@ function traverseAllChildren(children, callback, traverseContext) {
 module.exports = traverseAllChildren;
 
 }).call(this,require('_process'))
-},{"./ReactInstanceHandles":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactInstanceHandles.js","./ReactTextComponent":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/ReactTextComponent.js","./invariant":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/warning.js":[function(require,module,exports){
+},{"./ReactInstanceHandles":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactInstanceHandles.js","./ReactTextComponent":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/ReactTextComponent.js","./invariant":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/invariant.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/warning.js":[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2014 Facebook, Inc.
@@ -18722,10 +18733,10 @@ if ("production" !== process.env.NODE_ENV) {
 module.exports = warning;
 
 }).call(this,require('_process'))
-},{"./emptyFunction":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/emptyFunction.js","_process":"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/react/react.js":[function(require,module,exports){
+},{"./emptyFunction":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/emptyFunction.js","_process":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/react.js":[function(require,module,exports){
 module.exports = require('./lib/React');
 
-},{"./lib/React":"/Users/tmcw/src/react-tag-list-input/node_modules/react/lib/React.js"}],"/Users/tmcw/src/react-tag-list-input/node_modules/uniq/uniq.js":[function(require,module,exports){
+},{"./lib/React":"/Users/mgthesecond/projects/react-tag-list-input/node_modules/react/lib/React.js"}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/uniq/uniq.js":[function(require,module,exports){
 "use strict"
 
 function unique_pred(list, compare) {
@@ -18784,7 +18795,7 @@ function unique(list, compare, sorted) {
 
 module.exports = unique
 
-},{}],"/Users/tmcw/src/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js":[function(require,module,exports){
+},{}],"/Users/mgthesecond/projects/react-tag-list-input/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js":[function(require,module,exports){
 // shim for using process in browser
 
 var process = module.exports = {};
@@ -18849,4 +18860,4 @@ process.chdir = function (dir) {
     throw new Error('process.chdir is not supported');
 };
 
-},{}]},{},["/Users/tmcw/src/react-tag-list-input/demo.jsx"]);
+},{}]},{},["/Users/mgthesecond/projects/react-tag-list-input/demo.jsx"]);

--- a/demo.jsx
+++ b/demo.jsx
@@ -16,7 +16,7 @@ var Demo = React.createClass({
       <div>
         <TagListForm
           tags={tags}
-          strict={true}
+          strict={false}
           onChange={this.onChange} />
       </div>
     );

--- a/index.jsx
+++ b/index.jsx
@@ -22,7 +22,7 @@ var TagListForm = React.createClass({
     e.preventDefault();
     if (!this.props.strict || this.tagIsValid(this.state.tag)) {
       this.setState({
-        tags: uniq(this.state.tags.concat([this.state.tag])),
+        tags: uniq(this.state.tags.concat([this.state.tag]), undefined, true),
         tag: ''
       }, this.fireChange);
     }
@@ -43,6 +43,16 @@ var TagListForm = React.createClass({
   },
   focusForm: function(e) {
     this.refs.tagInput.getDOMNode().focus();
+  },
+  handleBackspace: function(e){
+    if(e.keyCode == 8 && this.state.tags.length > 0 && this.state.tag.length==0){
+      this.setState({
+        tags: this.state.tags.filter(function(t,i){
+          return i !== (this.state.tags.length-1)
+        }, this)
+      }, this.fireChange);  
+      e.preventDefault();
+    }
   },
   render: function() {
     var currentTags = this.state.tags.reduce(function(memo, tag) {
@@ -76,6 +86,7 @@ var TagListForm = React.createClass({
             list={listId}
             value={this.state.tag}
             onChange={this.inputChange}
+            onKeyUp={this.handleBackspace}
             className='tag-list-form-input'
             type='text'/>
           <datalist id={listId}>


### PR DESCRIPTION
Adds a handler to allow for the backspace key to remove the tag immediately preceding.

Also changed uniq to assume that array of tags is sorted (since order of user entry is significant when backspacing).

I can make this configured via a flag if that is preferable.

Fixes #2 
